### PR TITLE
Include requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+passlib
+-e svn+http://dpkt.googlecode.com/svn/trunk/#egg=dpkt
+M2Crypto


### PR DESCRIPTION
Hopefully cut back on the number of "can't run chapcrack due to missing dependencies" issues.
